### PR TITLE
Remove several intermediate copies, just because we can.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Decodes JWT tokens
 ## Example
 
 ```
-cat < EOF > token.jwt
+cat <<EOF > token.jwt
 eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJsc2t5d2Fsa2VyIiwiaWF0IjoyMzMzNjY0MDB9.k-tTF2CIZ-vu6-syRnCw3Zlc4jwfBCXAQRAyk0mtmso
 EOF
 

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -1,12 +1,7 @@
-extern crate base64;
 use base64::decode;
-
-extern crate serde;
 use serde::{Deserialize, Serialize};
 use serde_json;
-
 use std::collections::HashMap;
-use std::str::from_utf8;
 
 /// JWT represents a JSON web token
 #[derive(Serialize, Deserialize, Debug)]
@@ -25,23 +20,20 @@ impl JWT {
     ///
     /// ```
     /// let token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJsc2t5d2Fsa2VyIiwiaWF0IjoyMzMzNjY0MDB9.k-tTF2CIZ-vu6-syRnCw3Zlc4jwfBCXAQRAyk0mtmso";
-    /// let result = jwtdecode::jwt::JWT::new(token).unwrap();
+    /// let result = jwtdecode::jwt::JWT::new(token.to_string()).unwrap();
     /// assert_eq!(result.body.get("sub").unwrap(), "lskywalker");
     /// ```
-    pub fn new(s: &str) -> JWTResult {
-        let input_string = String::from(s);
+    pub fn new(input_string: String) -> JWTResult {
         let parts: Vec<&str> = input_string.splitn(3, '.').collect::<Vec<&str>>();
         if parts.len() != 3 {
             return Err(JWTError::from("Not enough parts for a valid jwt"));
         }
 
-        let decoded_header = &decode(parts[0])?;
-        let decoded_header_str = from_utf8(decoded_header)?;
-        let header = serde_json::from_str(decoded_header_str)?;
+        let decoded_header = decode(parts[0])?;
+        let header = serde_json::from_slice(&decoded_header)?;
 
-        let decoded_body = &decode(parts[1])?;
-        let decoded_body_str = from_utf8(decoded_body)?;
-        let body = serde_json::from_str(decoded_body_str)?;
+        let decoded_body = decode(parts[1])?;
+        let body = serde_json::from_slice(&decoded_body)?;
 
         Ok(JWT {
             header: header,
@@ -59,7 +51,7 @@ mod tests {
     #[test]
     fn jwt_new_valid() {
         let valid_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
-        let result = JWT::new(valid_token).unwrap();
+        let result = JWT::new(valid_token.to_string()).unwrap();
 
         assert_eq!(result.header.get("typ").unwrap(), "JWT");
         assert_eq!(result.header.get("alg").unwrap(), "HS256");


### PR DESCRIPTION
.. Also rely on 2018 edition's "? in main" feature to print error
returns.  In particular, this now prints the error (if any) to stderr,
and exits non-zero.

Note, this changes the "public" API of the library to accept a
`String` rather than `&str`, since the code currently requires an
owned copy of the input.  Since this is the public entry point, it
probably deserves a decision around intention/semantics rather than
just what the current implementation does.

Some possible alternatives might be:
- `JWT::new(&str) -> JWT`: Don't keep the full original input after
  `new()` has finished.  Currently the `token` property is private and
  unused.
- `JWT::new(&'a str) -> JWT<'a>`: Keep a borrowed reference to the
  input.